### PR TITLE
feature: v0.0.9

### DIFF
--- a/bobrix.go
+++ b/bobrix.go
@@ -111,9 +111,9 @@ func (bx *Bobrix) Bot() mxbot.Bot {
 }
 
 type ServiceRequest struct {
-	ServiceName string
-	MethodName  string
-	InputParams map[string]any
+	ServiceName string         `json:"service"`
+	MethodName  string         `json:"method"`
+	InputParams map[string]any `json:"inputs"`
 }
 
 type ServiceHandle func(evt *event.Event) *ServiceRequest

--- a/contracts/context.go
+++ b/contracts/context.go
@@ -46,7 +46,10 @@ type HandlerContext interface {
 	// JSON populates the outputs by marshaling and unmarshaling the provided data.
 	JSON(data any) error
 
+	// Messages returns all messages in the context.
 	Messages() Messages
+
+	// SetMessages sets the messages in the context.
 	SetMessages(messages Messages)
 }
 
@@ -64,6 +67,7 @@ type DefaultHandlerContext struct {
 
 type HandlerContextOpts func(handlerContext HandlerContext)
 
+// WithMessages returns a HandlerContextOpts that sets the messages in the handler context.
 func WithMessages(messages Messages) HandlerContextOpts {
 	return func(handlerContext HandlerContext) {
 		handlerContext.SetMessages(messages)

--- a/contracts/io.go
+++ b/contracts/io.go
@@ -1,5 +1,10 @@
 package contracts
 
+import (
+	"fmt"
+	"strconv"
+)
+
 // IOType represents the type of input or output in a method (e.g., text, audio, image).
 type IOType string
 
@@ -27,7 +32,25 @@ type Input struct {
 
 // SetValue sets the internal value of the input.
 func (i *Input) SetValue(value any) {
-	i.value = value
+
+	switch i.Type {
+	case IOTypeNumber:
+		float, err := strconv.ParseFloat(fmt.Sprintf("%v", value), 64)
+		if err != nil {
+			panic(err)
+		}
+
+		i.value = float
+	case IOTypeBoolean:
+		boolValue, err := strconv.ParseBool(fmt.Sprintf("%v", value))
+		if err != nil {
+			panic(err)
+		}
+
+		i.value = boolValue
+	default:
+		i.value = value
+	}
 }
 
 // Value returns the internal value of the input.

--- a/examples/ada/bot.go
+++ b/examples/ada/bot.go
@@ -31,10 +31,10 @@ func NewAdaBot(credentials *mxbot.BotCredentials) (*bobrix.Bobrix, error) {
 
 	bobr := bobrix.NewBobrix(bot, bobrix.WithHealthcheck(bobrix.WithAutoSwitch()))
 
-	bobr.SetContractParser(bobrix.DefaultContractParser(bobr.Bot().UserID()))
+	bobr.SetContractParser(bobrix.DefaultContractParser(bobr.Bot()))
 
 	bobr.SetContractParser(bobrix.AutoRequestParser(&bobrix.AutoParserOpts{
-		MXClient:    bot.Client(),
+		Bot:         bot,
 		ServiceName: "ada",
 		MethodName:  "generate",
 		InputName:   "prompt",

--- a/mxbot/context.go
+++ b/mxbot/context.go
@@ -87,7 +87,9 @@ type DefaultCtx struct {
 	handlesStatus *handlesStatus
 }
 
-var MetadataKeyContext = struct{}{}
+type MetadataKey struct{}
+
+var MetadataKeyContext = MetadataKey{}
 
 func injectMetadataInContext(ctx context.Context, evt *event.Event, bot Bot) context.Context {
 	metadata := map[string]any{


### PR DESCRIPTION
### Major Changes

1. **Enhanced Type Parsing in `SetValue` Method for Input Struct**: Implemented type-specific parsing logic within the `SetValue` method, enabling automatic conversion of input values to `float` for `IOTypeNumber` and `boolean` for `IOTypeBoolean`.

2. **New `LoopTyping` Function in `DefaultBot`**: Added `LoopTyping` to start and stop typing notifications on a specified room at set intervals. This feature repeatedly sends typing signals to indicate activity until explicitly stopped. It provides a `cancelTyping` function for cleaner control over typing notifications during bot conversations.

3. **Refactor of `FilterTagMe` and `FilterPrivateRoom` Functions**: Refactored multiple `mxbot.Filter` functions, like `FilterTagMe` and `FilterPrivateRoom`, to utilize the `Bot` struct rather than separate user ID or client parameters. This change increases modularity and simplifies the handling of event filters.

4. **Unified Contract Parsers to Use `Bot` Struct**: Updated the `DefaultContractParser` and `AutoRequestParser` functions to accept a `Bot` object rather than a user ID, streamlining access to bot-related attributes and reducing parameter redundancy.

5. **New `BobrixContractParser`**: Now, `BobrixContractParser` to use a structured approach for request validation and JSON parsing with improved error logging. This adjustment bolsters error handling and enhances the accuracy of request data extraction in bot commands.

---

### Minor Changes

1. **Additional JSON Tags in `ServiceRequest` Struct**: Added JSON tags to `ServiceName`, `MethodName`, and `InputParams` fields, allowing automatic JSON parsing compatibility with external APIs and cleaner serialization/deserialization.

2. **Metadata Key Refactoring**: Updated `MetadataKeyContext` to use a struct for better context handling within `injectMetadataInContext`, enhancing clarity around metadata management.

3. **Documentation and Comment Enhancements**: Added descriptive comments for several functions, such as `FilterNotInRoom` and `FilterInviteMe`, detailing their intended use cases and behavior.