### PR TITLE
fix olm keys wher restart container

### DIFF
--- a/bobrix.go
+++ b/bobrix.go
@@ -78,7 +78,14 @@ func (bx *Bobrix) Run(ctx context.Context) error {
 }
 
 func (bx *Bobrix) Stop(ctx context.Context) error {
-	return bx.bot.StopListening(ctx)
+	stopErr := bx.bot.StopListening(ctx)
+
+	if closeErr := bx.bot.Close(); closeErr != nil {
+		bx.logger.Error("failed to close bot crypto store", "error", closeErr)
+		return errors.Join(stopErr, closeErr)
+	}
+
+	return stopErr
 }
 
 // ConnectService - add service to the bot

--- a/mxbot/application/bot/infra.go
+++ b/mxbot/application/bot/infra.go
@@ -170,6 +170,10 @@ func (b *DefaultBot) ObserveEvent(evt *event.Event) {
 	b.crypto.ObserveEvent(evt)
 }
 
+func (b *DefaultBot) Close() error {
+	return b.crypto.Close()
+}
+
 // ----- EventDispatcher
 
 func (b *DefaultBot) AddEventHandler(h handlers.EventHandler) {

--- a/mxbot/domain/bot/crypto.go
+++ b/mxbot/domain/bot/crypto.go
@@ -19,4 +19,8 @@ type BotCrypto interface {
 	HandleToDevice(ctx context.Context, evt *event.Event)
 
 	ObserveEvent(evt *event.Event)
+
+	// Close flushes and closes the crypto store. Call it during graceful
+	// shutdown so persisted olm account state does not go stale.
+	Close() error
 }

--- a/mxbot/infrastructure/matrix/constructor/bot.go
+++ b/mxbot/infrastructure/matrix/constructor/bot.go
@@ -130,6 +130,23 @@ func NewMatrixBot(cfg Config) (*MatrixBot, error) {
 
 	// --- crypto
 	cryptoSvc, err := crypto.New(rawClient, cfg.Credentials.PickleKey, cfg.Credentials.Username)
+	if crypto.IsAccountKeyMismatch(err) {
+		cfg.Logger.Warn().Err(err).Msg(
+			"local olm account is out of sync with the homeserver (likely a stale crypto store " +
+				"left over from an unclean restart); resetting local crypto state and re-authorizing with a new device",
+		)
+
+		if resetErr := crypto.ResetLocalState(cfg.Credentials.Username); resetErr != nil {
+			return nil, fmt.Errorf("failed to reset local crypto state after olm account mismatch: %w", resetErr)
+		}
+
+		// device id file was just removed, so this login will register a brand-new device
+		if err := authSvc.Authorize(context.Background()); err != nil {
+			return nil, fmt.Errorf("re-authorize after crypto reset: %w", err)
+		}
+
+		cryptoSvc, err = crypto.New(rawClient, cfg.Credentials.PickleKey, cfg.Credentials.Username)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/mxbot/infrastructure/matrix/crypto/service.go
+++ b/mxbot/infrastructure/matrix/crypto/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"maunium.net/go/mautrix"
@@ -17,9 +18,49 @@ import (
 	utils "github.com/tensved/bobrix/mxbot/infrastructure/utils"
 )
 
+// olmAccountMismatchMsg is returned by mautrix's cryptohelper when the locally
+// persisted olm account is not marked as shared, but the homeserver already has
+// device keys for this device. This happens when the local crypto store
+// (.bin/crypto/store-*.db) is stale or was not flushed cleanly (e.g. the process
+// was killed between uploading keys to the server and persisting the "shared"
+// flag locally), while the device id itself was reused from a previous run.
+const olmAccountMismatchMsg = "olm account is not marked as shared, but there are keys on the server"
+
+// IsAccountKeyMismatch reports whether err is the local/remote olm account
+// desync described above.
+func IsAccountKeyMismatch(err error) bool {
+	return err != nil && strings.Contains(err.Error(), olmAccountMismatchMsg)
+}
+
+// ResetLocalState removes the persisted crypto store and saved device id for
+// the given bot username, forcing a brand-new device and olm account to be
+// created on the next login. Use this to recover from IsAccountKeyMismatch.
+func ResetLocalState(name string) error {
+	safeUser := utils.SafeFilePart(name)
+	dir := filepath.Join(".bin", "crypto")
+
+	matches, err := filepath.Glob(filepath.Join(dir, "store-"+safeUser+".db*"))
+	if err != nil {
+		return fmt.Errorf("glob crypto store: %w", err)
+	}
+	for _, m := range matches {
+		if err := os.Remove(m); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", m, err)
+		}
+	}
+
+	deviceIDFile := filepath.Join(dir, fmt.Sprintf("device-id-%s.txt", safeUser))
+	if err := os.Remove(deviceIDFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", deviceIDFile, err)
+	}
+
+	return nil
+}
+
 type Service struct {
 	client  *mautrix.Client
 	machine *crypto.OlmMachine
+	helper  *cryptohelper.CryptoHelper
 
 	encMu   sync.RWMutex
 	encRoom map[id.RoomID]bool
@@ -52,8 +93,20 @@ func New(client *mautrix.Client, pickleKey []byte, name string) (*Service, error
 	return &Service{
 		client:  client,
 		machine: m,
+		helper:  helper,
 		encRoom: make(map[id.RoomID]bool),
 	}, nil
+}
+
+// Close flushes and closes the underlying crypto store. It must be called
+// during a graceful shutdown so the olm account's "shared" state is
+// persisted to disk; skipping this is what allows the local store to end up
+// stale relative to the homeserver after a restart (see IsAccountKeyMismatch).
+func (s *Service) Close() error {
+	if s == nil || s.helper == nil {
+		return nil
+	}
+	return s.helper.Close()
 }
 
 func (s *Service) IsEncrypted(evt *event.Event) bool {


### PR DESCRIPTION
### Fixed

- **Crash-looping restarts due to olm account/device desync** — after a plain container restart (stop/start, not recreate), the bot could panic on startup with `olm account is not marked as shared, but there are keys on the server`. This happened because the local crypto store (`.bin/crypto/store-*.db`) was never flushed/closed on shutdown, so it could fall out of sync with the homeserver, which already had the device's keys.
    - `BotCrypto` now correctly closes and flushes its crypto store on graceful shutdown (`Bobrix.Stop` → `DefaultBot.Close()` → `crypto.Service.Close()`), preventing the desync in the first place.
    - If the desync still occurs (e.g. after an unclean kill), the bot self-heals on next startup instead of crashing: it detects the specific mismatch (`crypto.IsAccountKeyMismatch`), resets the local crypto state and device id (`crypto.ResetLocalState`), and re-authorizes with a fresh device.

### Changed

- **Breaking (internal):** `dbot.BotCrypto` interface now requires a `Close() error` method. Custom implementations of `BotCrypto` must add this method.